### PR TITLE
Added support for negative values

### DIFF
--- a/SenseSankey.js
+++ b/SenseSankey.js
@@ -81,6 +81,16 @@ define(
 									defaultValue: "#999999"
 									},
 									
+								flowColorNegative:{
+									type: "string",
+									component: "color-picker",
+									expression: "optional",
+									label: "Color Negative Flow",
+									ref: "flowColorNegative",
+									dualOutput: true,
+									defaultValue: "#f99999"
+									},
+									
 								Separateur:{
 									ref: "displaySeparateur",
 									type: "string",
@@ -424,6 +434,7 @@ define(
 					
 			//var flowColor = (layout.flowChoice == 2) ? layout.flowColorCustom : Theme.palette[layout.flowColor];
 			var flowColor = layout.flowColorCustom.color;
+			var flowColorNegative = layout.flowColorNegative && layout.flowColorNegative.color || '#f99999';  // flowColor;
 			  
 			var qData = layout.qHyperCube.qDataPages[0];
 			  // create a new array that contains the dimension labels
@@ -541,14 +552,15 @@ define(
 									////console.info(this);
 									tFlag = "yes";
 									v.value = v.value + val;
-
+									v.absValue = v.absValue + Math.abs(val);
 								}
 							});
 							if (tFlag == "no") {
 								sLinks.push({
 									"source" : cS,
 									"target" : cT,
-									"value" : val
+									"value" : val,
+									"absValue" : Math.abs(val)
 								});
 							}
 
@@ -608,15 +620,15 @@ define(
 			sankey.nodes(jNodes).links(sLinks).layout(32);
 			
 			var link = svg.append("g").selectAll(".link").data(sLinks).enter().append("path").attr("class", "link").attr("d", path).style("stroke-width",function(d) {
+				// Minimum width
 			  return Math.max(1, d.dy);
+			  }).style("stroke",function(d) {
+				// Color of Flow 
+				return (d.value < 0 ? flowColorNegative : flowColor);
 			}).sort(function(a, b) {
 			  return b.dy - a.dy;
 			});
 			
-			//Color of Flow 
-			link.style('stroke', flowColor);
-
-
 			$('.ttip').remove(); //We make sure there isn't any other tooltip div in the doom
 
 			// Create tooltip div 

--- a/sankeymore.js
+++ b/sankeymore.js
@@ -103,6 +103,10 @@ senseSankey = function() {
         d3.sum(node.sourceLinks, value),
         d3.sum(node.targetLinks, value)
       );
+      node.absValue = Math.max(
+        d3.sum(node.sourceLinks, absValue),
+        d3.sum(node.targetLinks, absValue)
+      );
     });
   }
  
@@ -174,18 +178,18 @@ senseSankey = function() {
  
     function initializeNodeDepth() {
       var ky = d3.min(nodesByBreadth, function(nodes) {
-        return (size[1] - (nodes.length - 1) * nodePadding) / d3.sum(nodes, value);
+        return (size[1] - (nodes.length - 1) * nodePadding) / d3.sum(nodes, absValue);
       });
  
       nodesByBreadth.forEach(function(nodes) {
         nodes.forEach(function(node, i) {
           node.y = i;
-          node.dy = node.value * ky;
+          node.dy = node.absValue * ky;
         });
       });
  
       links.forEach(function(link) {
-        link.dy = link.value * ky;
+        link.dy = link.absValue * ky;
       });
     }
  
@@ -193,14 +197,14 @@ senseSankey = function() {
       nodesByBreadth.forEach(function(nodes, breadth) {
         nodes.forEach(function(node) {
           if (node.targetLinks.length) {
-            var y = d3.sum(node.targetLinks, weightedSource) / d3.sum(node.targetLinks, value);
+            var y = d3.sum(node.targetLinks, weightedSource) / d3.sum(node.targetLinks, absValue);
             node.y += (y - center(node)) * alpha;
           }
         });
       });
  
       function weightedSource(link) {
-        return center(link.source) * link.value;
+        return center(link.source) * link.absValue;
       }
     }
  
@@ -208,14 +212,14 @@ senseSankey = function() {
       nodesByBreadth.slice().reverse().forEach(function(nodes) {
         nodes.forEach(function(node) {
           if (node.sourceLinks.length) {
-            var y = d3.sum(node.sourceLinks, weightedTarget) / d3.sum(node.sourceLinks, value);
+            var y = d3.sum(node.sourceLinks, weightedTarget) / d3.sum(node.sourceLinks, absValue);
             node.y += (y - center(node)) * alpha;
           }
         });
       });
  
       function weightedTarget(link) {
-        return center(link.target) * link.value;
+        return center(link.target) * link.absValue;
       }
     }
  
@@ -289,6 +293,10 @@ senseSankey = function() {
  
   function value(link) {
     return link.value;
+  }
+ 
+  function absValue(link) {
+    return link.absValue;
   }
  
   return sankey;


### PR DESCRIPTION
Hi! 

Thank you for your work on the Sankey.  I've used it, and I now needed support for negative values. I also saw your comment in the Qlik Branch Garden about adding support for it.

Adding fabs() is a workaround, but its shortcomings are that the total sum for a node gets incorrect if the node has both positive and negative links.

Here is one way of solving it.  Parts of the graph need to use the absolute value (link thicknesses), with other need actual value (node sum).  I therefor added a new attribute, absValue to the links.

Negative flows can now be shown with a different color.

Feel free to use this solution, or some other solution.  :)

Thank you,
Vegard