### PR TITLE
Implement export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Original radar chart extension, developped by John Park : <a href="http://branch
 Mike Bostock's Sankey chart : <a href="http://bost.ocks.org/mike/sankey">here</a><br>
 D3.js
 
-V2.33 Added support for negative values by vbakke
+V2.34 Added export support by [julmot](https://github.com/julmot)
+
+V2.33 Added support for negative values by [vbakke](https://github.com/vbakke)
 
 V2.32 Update code to be compatible with September 2018
 

--- a/SenseSankey.js
+++ b/SenseSankey.js
@@ -337,12 +337,11 @@ define(
 				}
 			},
 			snapshot: {
-						canTakeSnapshot: true
-					},
-				
-			
-			
-
+				canTakeSnapshot: true
+			},
+			support : {
+				export: true
+			},
 			paint: function ( $element, layout ) {
 				
 			// Fonction format pop-up		

--- a/SenseSankey.qext
+++ b/SenseSankey.qext
@@ -3,7 +3,7 @@
 	"description": "Sankey Graph",
 	"icon": "extension",
 	"type": "visualization",
-	"version": 1.2,
+	"version": 2.34,
 	"preview" : "sankey.png",
 	"author": "QlikTech International AB"
 }


### PR DESCRIPTION
This PR should make it possible to export as PowerPoint. Currently, when creating a snapshot, then inserting that snapshot into a "Story", then exporting the story as PowerPoint it will result in an empty rectangle. After this change, it will convert the visualization into an image and correctly exports to PowerPoint.